### PR TITLE
fixed Kali Linux menuentry

### DIFF
--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -240,12 +240,12 @@ menuentry "Ubuntu 20.04 Live ISO" --class ubuntu --class linux {
 # Kali Linux
 menuentry "Kali Linux Live ISO" --class kali --class linux {
     set root='(hd0,1)'
-    set isofile="/path/to/iso"
+    set isofile="/kali-linux-2020.4-live-amd64.iso"
     insmod ext2
     insmod loopback
     insmod iso9660
     loopback loop $isofile
-    linux (loop)/live/vmlinuz boot=live quiet splash vt.global_cursor_default=0 loglevel=2 rd.systemd.show_status=false rd.udev.log-priority=3 sysrq_always_enabled=1 cow_spacesize=1G fromiso=/dev/sda1/$isofile noconfig=sudo username=root hostname=kali
+    linux (loop)/live/vmlinuz boot=live components quiet splash noeject findiso=${isofile}
     initrd (loop)/live/initrd.img
 }
 


### PR DESCRIPTION
Previous menuentry wasn't working with kali-linux-2020.4-live-amd64.iso so I made a few changes to kernel parameters